### PR TITLE
Fallback to x64 binaries on Windows arm64

### DIFF
--- a/ext/sass/Rakefile
+++ b/ext/sass/Rakefile
@@ -232,7 +232,8 @@ module Configuration
           when 'x86_64'
             'x64'
           when 'aarch64'
-            'arm64'
+            # No arm64 binaries available for Windows but we can try emulation
+            Platform::OS == 'windows' ? 'x64' : 'arm64'
           when 'arm'
             'arm'
           else
@@ -268,7 +269,8 @@ module Configuration
           when 'x86_64'
             'x86_64'
           when 'aarch64'
-            'aarch_64'
+            # No arm64 binaries available for Windows but we can try emulation
+            Platform::OS == 'windows' ? 'x86_64' : 'aarch_64'
           when 'powerpc64le'
             'ppcle_64'
           when 's390x'


### PR DESCRIPTION
It'd be useful to have this working on Windows 11 ARM64. Windows 10 and 11 are available on arm64 now, although this isn't so commonly used, I understand :-)

I test/validate Windows builds of [GoCD](https://github.com/gocd/gocd) via a VM, and now finally have an M1 MacBook Pro so running via an ARM64 VM is far faster than trying to emulate an entire x64 Windows machine.

Running a sass compile via the x64 dart.exe seems to be fine for me on Windows ARM64. It's worth noting that I have only validated via a JRuby install right now, which is an even more obscure use case. Testing on actual Ruby seems to be blocked for me right now by https://github.com/oneclick/rubyinstaller2/issues/308 and https://bugs.ruby-lang.org/issues/18605 which seems to prevent me actually using Ruby 3.1 on Windows ARM64.