### PR TITLE
Drop Ruby 2.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -78,7 +77,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -115,7 +113,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -164,7 +161,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - '**/*_pb.rb'
     - 'vendor/**/*'
 
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
   NewCops: enable
 

--- a/lib/sass/embedded/structifier.rb
+++ b/lib/sass/embedded/structifier.rb
@@ -18,11 +18,7 @@ module Sass
           value = obj[key]
           if value.respond_to? :call
             struct.define_singleton_method key do |*args, **kwargs|
-              if kwargs.empty?
-                value.call(*args)
-              else
-                value.call(*args, **kwargs)
-              end
+              value.call(*args, **kwargs)
             end
           else
             struct.define_singleton_method key do

--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec| # rubocop:disable Gemspec/RequireMFA
     ]
   end
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_runtime_dependency 'google-protobuf', '~> 3.21'
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/branches/

Ruby 2.6
status: eol
release date: 2018-12-25
normal maintenance until: 2021-04-01
EOL: 2022-04-12

Only reason that this gem targeted Ruby 2.6 was for JRuby 9.3 compatibility. Now JRuby 9.4 (Ruby 3.1 Language support) has been released for 3 month, it is a good time to drop the outdated Ruby 2.6.