### PR TITLE
Detect x86 emulation for Windows on Arm

### DIFF
--- a/ext/sass/Rakefile
+++ b/ext/sass/Rakefile
@@ -255,7 +255,24 @@ module Configuration
           when 'x86_64'
             'x64'
           when 'aarch64'
-            'arm64'
+            if Platform::OS == 'windows'
+              begin
+                require_relative 'win32_api'
+
+                if Win32API.x64?
+                  'x64'
+                elsif Win32API.x86?
+                  'ia32'
+                else
+                  raise NotImplementedError, message
+                end
+              rescue LoadError
+                # TODO: remove begin/rescue once jruby/jffi support windows aarch64
+                'ia32'
+              end
+            else
+              'arm64'
+            end
           when 'arm'
             'arm'
           else
@@ -295,7 +312,24 @@ module Configuration
           when 'x86_64'
             'x86_64'
           when 'aarch64'
-            'aarch_64'
+            if Platform::OS == 'windows'
+              begin
+                require_relative 'win32_api'
+
+                if Win32API.x64?
+                  'x86_64'
+                elsif Win32API.x86?
+                  'x86_32'
+                else
+                  raise NotImplementedError, message
+                end
+              rescue LoadError
+                # TODO: remove begin/rescue once jruby/jffi support windows aarch64
+                'x86_32'
+              end
+            else
+              'aarch_64'
+            end
           when 'powerpc64le'
             'ppcle_64'
           when 's390x'

--- a/ext/sass/win32_api.rb
+++ b/ext/sass/win32_api.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'fiddle'
+
+# @see https://learn.microsoft.com/en-us/windows/win32/api/
+module Win32API
+  Kernel32 = Fiddle.dlopen('Kernel32.dll')
+
+  # @see https://learn.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants
+  module ImageFileMachineConstants
+    IMAGE_FILE_MACHINE_I386 = 0x014c
+    IMAGE_FILE_MACHINE_ARMNT = 0x01c4
+    IMAGE_FILE_MACHINE_AMD64 = 0x8664
+    IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+  end
+
+  private_constant :ImageFileMachineConstants
+
+  # @see https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ne-processthreadsapi-machine_attributes
+  module MachineAttributes
+    USER_ENABLED = 0x00000001
+    KERNEL_ENABLED = 0x00000002
+    WOW64_CONTAINER = 0x00000004
+  end
+
+  private_constant :MachineAttributes
+
+  # Specifies the ways in which an architecture of code can run on a host operating system.
+  class MachineTypeAttributes
+    def initialize(machine_type_attributes)
+      @machine_type_attributes = machine_type_attributes
+    end
+
+    # The specified architecture of code can run in user mode.
+    def user_enabled?
+      @machine_type_attributes & MachineAttributes::USER_ENABLED == MachineAttributes::USER_ENABLED
+    end
+
+    # The specified architecture of code can run in kernel mode.
+    def kernel_enabled?
+      @machine_type_attributes & MachineAttributes::KERNEL_ENABLED == MachineAttributes::KERNEL_ENABLED
+    end
+
+    # The specified architecture of code runs on WOW64.
+    def wow64_container?
+      @machine_type_attributes & MachineAttributes::WOW64_CONTAINER == MachineAttributes::WOW64_CONTAINER
+    end
+  end
+
+  private_constant :MachineTypeAttributes
+
+  class << self
+    def x86?
+      get_machine_type_attributes(ImageFileMachineConstants::IMAGE_FILE_MACHINE_I386).user_enabled?
+    end
+
+    def arm?
+      get_machine_type_attributes(ImageFileMachineConstants::IMAGE_FILE_MACHINE_ARMNT).user_enabled?
+    end
+
+    def x64?
+      get_machine_type_attributes(ImageFileMachineConstants::IMAGE_FILE_MACHINE_AMD64).user_enabled?
+    end
+
+    def arm64?
+      get_machine_type_attributes(ImageFileMachineConstants::IMAGE_FILE_MACHINE_ARM64).user_enabled?
+    end
+
+    private
+
+    begin
+      # @see https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getmachinetypeattributes
+      GetMachineTypeAttributes = Fiddle::Function.new(
+        Kernel32['GetMachineTypeAttributes'],
+        [-Fiddle::TYPE_SHORT, Fiddle::TYPE_VOIDP],
+        Fiddle::TYPE_LONG
+      )
+
+      def get_machine_type_attributes(machine)
+        p_machine_type_attributes = Fiddle::Pointer.malloc(Fiddle::SIZEOF_INT, Fiddle::RUBY_FREE)
+        raise Fiddle.win32_last_error unless GetMachineTypeAttributes.call(machine, p_machine_type_attributes).zero?
+
+        MachineTypeAttributes.new(p_machine_type_attributes.to_str.unpack1('i'))
+      end
+    rescue Fiddle::DLError
+      # @see https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess
+      GetCurrentProcess = Fiddle::Function.new(
+        Kernel32['GetCurrentProcess'],
+        [],
+        Fiddle::TYPE_VOIDP
+      )
+
+      # @see https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process2
+      IsWow64Process2 = Fiddle::Function.new(
+        Kernel32['IsWow64Process2'],
+        [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP],
+        Fiddle::TYPE_CHAR
+      )
+
+      # @see https://learn.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64guestmachinesupported
+      IsWow64GuestMachineSupported = Fiddle::Function.new(
+        Kernel32['IsWow64GuestMachineSupported'],
+        [-Fiddle::TYPE_SHORT, Fiddle::TYPE_VOIDP],
+        Fiddle::TYPE_LONG
+      )
+
+      def get_machine_type_attributes(machine)
+        h_process = GetCurrentProcess.call
+        p_process_machine = Fiddle::Pointer.malloc(Fiddle::SIZEOF_SHORT, Fiddle::RUBY_FREE)
+        p_native_machine = Fiddle::Pointer.malloc(Fiddle::SIZEOF_SHORT, Fiddle::RUBY_FREE)
+        raise Fiddle.win32_last_error if IsWow64Process2.call(h_process, p_process_machine, p_native_machine).zero?
+
+        if p_native_machine.to_str.unpack1('S!') == machine
+          return MachineTypeAttributes.new(
+            MachineAttributes::USER_ENABLED |
+            MachineAttributes::KERNEL_ENABLED |
+            MachineAttributes::WOW64_CONTAINER
+          )
+        end
+
+        p_machine_is_supported = Fiddle::Pointer.malloc(Fiddle::SIZEOF_CHAR, Fiddle::RUBY_FREE)
+        raise Fiddle.win32_last_error unless IsWow64GuestMachineSupported.call(machine, p_machine_is_supported).zero?
+
+        if p_machine_is_supported.to_str.unpack1('c').zero?
+          MachineTypeAttributes.new(0)
+        else
+          MachineTypeAttributes.new(
+            MachineAttributes::USER_ENABLED |
+            MachineAttributes::WOW64_CONTAINER
+          )
+        end
+      end
+    end
+  end
+end

--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec| # rubocop:disable Gemspec/RequireMFA
     spec.files += Dir['ext/sass/*_pb.rb'] + [
       'ext/sass/expand-archive.ps1',
       'ext/sass/package.json',
+      'ext/sass/win32_api.rb',
       'ext/sass/Rakefile'
     ]
   end


### PR DESCRIPTION
This PR detects x86 emulation for Windows on Arm and picks x64 or x86 binary base on what's supported.