### PR TITLE
Breaking change on importer function signature

### DIFF
--- a/lib/sass/canonicalize_context.rb
+++ b/lib/sass/canonicalize_context.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Sass
+  # Contextual information passed to `canonicalize` and `find_file_url`.
+  # Not all importers will need this information to resolve loads, but some may find it useful.
+  #
+  # @see https://sass-lang.com/documentation/js-api/interfaces/canonicalizecontext/
+  class CanonicalizeContext
+    # @return [String, nil]
+    attr_reader :containing_url
+
+    # @return [Boolean]
+    attr_reader :from_import
+
+    def initialize(containing_url, from_import)
+      @containing_url = containing_url
+      @from_import = from_import
+    end
+  end
+end

--- a/lib/sass/embedded.rb
+++ b/lib/sass/embedded.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../../ext/sass/cli'
+require_relative 'canonicalize_context'
 require_relative 'compile_error'
 require_relative 'compile_result'
 require_relative 'embedded/connection'

--- a/lib/sass/embedded/protofier.rb
+++ b/lib/sass/embedded/protofier.rb
@@ -8,6 +8,13 @@ module Sass
     module Protofier
       module_function
 
+      def from_proto_canonicalize_context(canonicalize_request)
+        CanonicalizeContext.new(
+          canonicalize_request.containing_url == '' ? nil : canonicalize_request.containing_url,
+          canonicalize_request.from_import
+        )
+      end
+
       def from_proto_compile_response(compile_response)
         oneof = compile_response.result
         result = compile_response.public_send(oneof)


### PR DESCRIPTION
In theory we could add `containing_url` as another keyword argument. However, this approach would risk in the future for others who are declaring explicit keyword arguments without having `**` to catch extra keyword arguments, that adding any keyword argument will still be a breaking change. Therefore it is decided to convert this to pass an object just like how JS-API works, that we can add more properties in the future without breaking users.