### PR TITLE
Fix concurrency issue with writev

### DIFF
--- a/lib/sass/embedded/connection.rb
+++ b/lib/sass/embedded/connection.rb
@@ -11,6 +11,7 @@ module Sass
     # It runs the `sass --embedded` command.
     class Connection
       def initialize(dispatcher)
+        @mutex = Mutex.new
         @stdin, stdout, stderr, @wait_thread = begin
           Open3.popen3(*CLI::COMMAND, '--embedded', chdir: __dir__)
         rescue Errno::ENOENT
@@ -59,7 +60,9 @@ module Sass
         buffer = []
         Varint.write(buffer, Varint.length(id) + proto.length)
         Varint.write(buffer, id)
-        @stdin.write(buffer.pack('C*'), proto)
+        @mutex.synchronize do
+          @stdin.write(buffer.pack('C*'), proto)
+        end
       end
     end
 


### PR DESCRIPTION
`writev` is not guaranteed to be atomic, even on posix. See discussion on https://bugs.ruby-lang.org/issues/19642.

- Closes #168.

