### PR TITLE
Remove required_rubygems_version

### DIFF
--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec| # rubocop:disable Gemspec/RequireMFA
   if ENV.key?('gem_platform')
     spec.files += Dir['ext/sass/dart-sass/**/*'] + ['ext/sass/cli.rb']
     spec.platform = ENV['gem_platform']
-    spec.required_rubygems_version = '>= 3.3.22' if ENV['gem_platform'].include?('-linux-')
   else
     spec.extensions = ['ext/sass/Rakefile']
     spec.files += [


### PR DESCRIPTION
Although the native linux gems do require rubygems 3.3.22 / bundler 2.3.22 or higher to install correctly, it turns out some vendors like Debian patch rubygems (e.g. 3.4.20 in Debian unstable) to behave like version 3.3.15, which completely breaks the `spec.required_rubygems_version = '>= 3.3.22'` safeguard.

``` diff
diff --git a/lib/rubygems/platform.rb b/lib/rubygems/platform.rb
index b721629b7..a16c6fca9 100644
--- a/lib/rubygems/platform.rb
+++ b/lib/rubygems/platform.rb
@@ -117,6 +117,9 @@ def initialize(arch)
       when /^(\w+_platform)(\d+)?/ then [ $1,          $2  ]
       else                              [ "unknown",   nil ]
       end
+
+      # emulate behavior from 3.3.15 on ruby 3.1
+      @version = nil if (RUBY_VERSION < "3.2" && @os == "linux")
     when Gem::Platform then
       @cpu = arch.cpu
       @os = arch.os
```

While it is possible to update the requirement to `spec.required_rubygems_version = '>= 3.4.21'` to block Debian's broken rubygems, it would also block most of users who have a working installation with rubygems <3.4.21.

So Debian screwed it up and nothing can be done in here to remediate the issue. This check is now kind of useless therefore removing it.