### PR TITLE
Support idle_timeout in global compiler

### DIFF
--- a/lib/sass/compiler.rb
+++ b/lib/sass/compiler.rb
@@ -26,7 +26,7 @@ module Sass
   #   sass.close
   class Compiler
     def initialize
-      @dispatcher = ResilientDispatcher.new
+      @dispatcher = ResilientDispatcher.new(Dispatcher)
     end
 
     # Compiles the Sass file at +path+ to CSS.

--- a/lib/sass/compiler/dispatcher.rb
+++ b/lib/sass/compiler/dispatcher.rb
@@ -35,7 +35,7 @@ module Sass
               close
             end
           else
-            @id = 1
+            idle
           end
         end
       end
@@ -88,6 +88,12 @@ module Sass
 
       def send_proto(...)
         @connection.write(...)
+      end
+
+      private
+
+      def idle
+        @id = 1
       end
 
       # The {Channel} between {Dispatcher} and {Host}.

--- a/lib/sass/compiler/resilient_dispatcher.rb
+++ b/lib/sass/compiler/resilient_dispatcher.rb
@@ -6,8 +6,9 @@ module Sass
     #
     # It recovers from failures and continues to function.
     class ResilientDispatcher
-      def initialize
-        @dispatcher = Dispatcher.new
+      def initialize(dispatcher_class)
+        @dispatcher_class = dispatcher_class
+        @dispatcher = @dispatcher_class.new
         @mutex = Mutex.new
       end
 
@@ -29,7 +30,7 @@ module Sass
         @mutex.synchronize do
           @dispatcher.connect(...)
         rescue Errno::EBUSY
-          @dispatcher = Dispatcher.new
+          @dispatcher = @dispatcher_class.new
           @dispatcher.connect(...)
         end
       end


### PR DESCRIPTION
This PR is a more performant alternative to https://github.com/ntkme/sassc-embedded-shim-ruby/pull/68.

It would close the global compiler process once it is idle for more than 10s, and restarts on next use. This is faster than running single-used compiler process every time, especially for compiling lots of files.