### PR TITLE
Bundle forked sass npm package with pure js embedded compiler support

### DIFF
--- a/.github/actions/build-dart-sass/action.yml
+++ b/.github/actions/build-dart-sass/action.yml
@@ -1,0 +1,55 @@
+# TODO: remove after https://github.com/sass/dart-sass/pull/2413
+name: Build dart-sass
+description: Build dart-sass from source with patch from https://github.com/sass/dart-sass/pull/2413
+runs:
+  using: composite
+  steps:
+    - uses: bufbuild/buf-setup-action@v1.50.0
+      with:
+        github_token: ${{ github.token }}
+
+    - uses: dart-lang/setup-dart@v1
+
+    - uses: actions/setup-node@v6
+
+    - id: version
+      run: node -e 'console.log(`version=${JSON.parse(fs.readFileSync("ext/sass/package.json"))["dependencies"]["sass"]}`)' | tee -a "$GITHUB_OUTPUT"
+      shell: bash
+
+    - uses: actions/checkout@v5
+      with:
+        repository: sass/dart-sass
+        ref: ${{ steps.version.outputs.version }}
+        path: dart-sass
+
+    - run: curl -fsSL -- https://github.com/sass/dart-sass/pull/2413.diff | git apply -
+      working-directory: dart-sass
+      shell: bash
+
+    - run: dart pub get
+      working-directory: dart-sass
+      shell: bash
+
+    - run: dart run grinder protobuf pkg-npm-release
+      working-directory: dart-sass
+      shell: bash
+
+    - run: npm pack
+      working-directory: dart-sass/build/npm
+      shell: bash
+
+    - run: mv dart-sass/build/npm/sass-${{ steps.version.outputs.version }}.tgz ext/sass
+      shell: bash
+
+    - run: npm install sass@file:sass-${{ steps.version.outputs.version }}.tgz
+      working-directory: ext/sass
+      shell: bash
+
+    - run: git add ext/sass/sass-${{ steps.version.outputs.version }}.tgz ext/sass/package.json
+      shell: bash
+
+    - run: git clean -dffx
+      shell: bash
+
+    - run: git diff HEAD
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,16 +138,15 @@ jobs:
               run: |
                 pkg_add node protobuf ruby%3.4 ruby-shims
                 echo 3.4 | tee /etc/ruby-version
-          - os: ubuntu-latest
-            vm:
-              os: omnios
-              run: |
-                pkg install build-essential node-22 protobuf ruby-34
-                pkg install "$(pkg search -HI -o pkg.name "$(ruby -e 'puts RbConfig::CONFIG["CC"]')")"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      # TODO: remove after https://github.com/sass/dart-sass/pull/2413
+      - name: Build dart-sass
+        if: matrix.vm
+        uses: ./.github/actions/build-dart-sass
 
       - name: Initialize vm
         if: matrix.vm
@@ -195,7 +194,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Spec
-        if: "!matrix.vm || contains(matrix.vm.run, 'linux_base') || contains(matrix.vm.run, '/proc')" # TODO: remove after https://github.com/sass/dart-sass/pull/2413
         run: bundle exec rake spec
 
       - name: Install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
           rubygems: latest
           bundler-cache: true
 
+      # TODO: remove after https://github.com/sass/dart-sass/pull/2413
+      - name: Build dart-sass
+        if: matrix.platform == 'ruby'
+        uses: ./.github/actions/build-dart-sass
+
       - name: Compile
         run: bundle exec rake compile ext_platform=${{ matrix.platform }}
         env:

--- a/ext/sass/Rakefile
+++ b/ext/sass/Rakefile
@@ -488,6 +488,8 @@ module SassConfig
 
   def dart_sass_version
     package_json['dependencies']['sass']
+      # TODO: remove after https://github.com/sass/dart-sass/pull/2413
+      .delete_prefix('file:sass-').delete_suffix('.tgz')
   end
 
   def dart_sass
@@ -606,8 +608,6 @@ module SassConfig
     tag_name = JSON.parse(version)['protocolVersion']
 
     "https://github.com/sass/sass/raw/embedded-protocol-#{tag_name}/spec/embedded_sass.proto"
-  rescue StandardError # TODO: remove after https://github.com/sass/dart-sass/pull/2413
-    'https://github.com/sass/sass/raw/HEAD/spec/embedded_sass.proto'
   end
 
   def development?

--- a/sass-embedded.gemspec
+++ b/sass-embedded.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   if spec.platform == Gem::Platform::RUBY
     spec.extensions = ['ext/sass/Rakefile']
+    spec.files += Dir['ext/sass/sass-*.tgz'] # TODO: remove after https://github.com/sass/dart-sass/pull/2413
     spec.files += [
       'ext/sass/Rakefile',
       'ext/sass/package.json'


### PR DESCRIPTION
https://github.com/sass/dart-sass/pull/2413 has passed all the tests, but it still remains blocked by some cosmetic issues (e.g. migrating from `dart:js` to `dart:js_interop`) in the upstream project after almost a year.

The wait has been too long. Therefore, this PR bundles the forked/patched npm package with pure js embedded compiler support. All the platforms without native dart support will work with node.   

- Closes #227